### PR TITLE
readme: Update docs to specify Clear Containers 3.0 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # sriov
 Simple standalone Docker Plugin implementation to demonstrate Clear Containers with SRIOV
 
-For more details about Clear Containers https://github.com/01org/cc-oci-runtime https://clearlinux.org/clear-containers
+For more details about Clear Containers https://github.com/clearcontainers https://clearlinux.org/clear-containers
 
 This plugin supports Docker containers with runc or Clear Containers as the OCI runtime. The plugin is responsible for assigning a SRIOV Virtual Function (VF) into the container namespace.
 
 In the case of runc containers, the VF is directly usable by the container. 
 
 In the case of clear containers, if clear containers detect a VF in the namespace, the runtime will unbind the VF from the host, bind it to VFIO and assign it to the clear container using PCI device pass thro.
-The clear container runtime which support SRIOV can be found at https://github.com/01org/cc-oci-runtime/tree/networking/sriov
+The clear container runtime which support SRIOV can be found at https://github.com/clearcontainers/runtime
 
 # How to use this plugin
 


### PR DESCRIPTION
Now that sriov support has been added in Clear Containers 3.0
runtime, update the docs to specify the url for the 3.0 runtime.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>