### PR TITLE
correct path for uuid import

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -31,7 +31,7 @@ import (
         "os"
         "strconv"
         "strings"
-	"github.com/01org/ciao/ssntp/uuid"
+	"github.com/01org/ciao/uuid"
 	"github.com/boltdb/bolt"
 	"github.com/docker/libnetwork/drivers/remote/api"
 	ipamapi "github.com/docker/libnetwork/ipams/remote/api"


### PR DESCRIPTION
Dependency 'uuid' is refactored in master branch of github.com/ciao-project/ciao.

Fixes issue #6 

Signed-off-by: Jesse Butler <jesse.butler@oracle.com>